### PR TITLE
Fix CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(
 
 find_package(Vulkan REQUIRED)
 
-if(EXISTS VulkanMemoryAllocator/CMakeLists.txt)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/VulkanMemoryAllocator/CMakeLists.txt)
     add_subdirectory(VulkanMemoryAllocator)
 else()
     find_package(VulkanMemoryAllocator REQUIRED)


### PR DESCRIPTION
Fixed #20 

As https://github.com/YaaZ/VulkanMemoryAllocator-Hpp/issues/20#issue-1465629982 said,
When we have this folder layout:
```
external/
    VulkanMemoryAllocator-Hpp/
    CMakeLists.txt
```
Adding `add_subdirectory(VulkanMemoryAllocator-Hpp)` in `CMakeLists.txt` could result in CMake failing when you don't have `VulkanMemoryAllocator` installed in the system.

Because 
```
if(EXISTS VulkanMemoryAllocator/CMakeLists.txt)
    add_subdirectory(VulkanMemoryAllocator)
else()
    find_package(VulkanMemoryAllocator REQUIRED)
endif()
```
in `VulkanMemoryAllocator-Hpp/CMakeLists.txt` always fall into the else branch.

Changing it to `if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/VulkanMemoryAllocator/CMakeLists.txt)` make sure always check in the dir where `VulkanMemoryAllocator-Hpp/CMakeLists.txt` are.


