### PR TITLE
Update cmake version to prevent depreciation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
 
 project(
     VulkanMemoryAllocator-Hpp


### PR DESCRIPTION
CMake warns that version <=3.5 will soon not be supported anymore. 
I am able to use CMake 3.27, so it is possible to increase the minimum version more if wanted.