### PR TITLE
fix duplicate symbol on 'void resultCheck' by adding VULKAN_HPP_INLINE

### DIFF
--- a/include/vk_mem_alloc.hpp
+++ b/include/vk_mem_alloc.hpp
@@ -227,7 +227,8 @@ createResultValueType(VULKAN_HPP_NAMESPACE::Result result, T &&data) {
 } // namespace VMA_HPP_NAMESPACE::detail
 
 namespace VMA_HPP_NAMESPACE::detail {
-void resultCheck(VULKAN_HPP_NAMESPACE::Result result, char const *message) {
+VULKAN_HPP_INLINE void 
+resultCheck(VULKAN_HPP_NAMESPACE::Result result, char const *message) {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
   VMA_HPP_NAMESPACE::detail::ignore(
       result); // just in case VULKAN_HPP_ASSERT_ON_RESULT is empty


### PR DESCRIPTION
Without this VULKAN_HPP_INLINE
there is a error with multiple definition of resultCheck

closes:
https://github.com/YaaZ/VulkanMemoryAllocator-Hpp/issues/48
https://github.com/YaaZ/VulkanMemoryAllocator-Hpp/issues/49