### PR TITLE
Updated cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.6...3.30 FATAL_ERROR)
 set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "0e5b6991-d74f-4b3d-a41c-cf096e0b2508")
 
 project(


### PR DESCRIPTION
Updated the minimum required CMake version as a range from the current 3.6 up to 3.30.
Relevant versions would be 3.28 for those who use Vulkan-Hpp as a c++20 module and 3.30 for `import std;`