### PR TITLE
Include <version> header before using library feature-test macro.

### DIFF
--- a/CppModule/modules-example.cpp
+++ b/CppModule/modules-example.cpp
@@ -1,3 +1,4 @@
+#include <version>
 #if defined(__cpp_lib_modules)
 import std;
 #else

--- a/Generate.java
+++ b/Generate.java
@@ -905,6 +905,7 @@ public class Generate {
         Files.writeString(Path.of("src/vk_mem_alloc.cppm"), processTemplate("""
                 module;
 
+                #include <version>
                 #if defined( __cpp_lib_modules )
                 #define VMA_ENABLE_STD_MODULE
                 #endif

--- a/src/vk_mem_alloc.cppm
+++ b/src/vk_mem_alloc.cppm
@@ -1,5 +1,6 @@
 module;
 
+#include <version>
 #if defined( __cpp_lib_modules )
 #define VMA_ENABLE_STD_MODULE
 #endif


### PR DESCRIPTION
Library feature-test macro is defined only if `<version>` header is included.