### PR TITLE
C++Module: Only export `to_string` if `VULKAN_HPP_NO_TO_STRING` is undefined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.6...3.30 FATAL_ERROR)
 set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "0e5b6991-d74f-4b3d-a41c-cf096e0b2508")
 
 project(

--- a/Generate.java
+++ b/Generate.java
@@ -924,7 +924,6 @@ public class Generate {
                   using VMA_HPP_NAMESPACE::operator~;
                   using VMA_HPP_NAMESPACE::to_string;
                   using VMA_HPP_NAMESPACE::functionsFromDispatcher;
-                  {{{using VMA_HPP_NAMESPACE::${toString};}}}
                 }
 
                 """, Stream.concat(Stream.concat(enums.stream(), structs.stream()), handles.stream()
@@ -939,6 +938,12 @@ public class Generate {
                   {{{using VMA_HPP_NAMESPACE::Unique${name};}}}
                   using VMA_HPP_NAMESPACE::createAllocatorUnique;
                   using VMA_HPP_NAMESPACE::createVirtualBlockUnique;
+                }
+                #endif
+
+                #ifndef VULKAN_HPP_NO_TO_STRING
+                export namespace VMA_HPP_NAMESPACE {
+                  {{{using VMA_HPP_NAMESPACE::${toString};}}}
                 }
                 #endif
 

--- a/Generate.java
+++ b/Generate.java
@@ -922,8 +922,8 @@ public class Generate {
                   using VMA_HPP_NAMESPACE::operator&;
                   using VMA_HPP_NAMESPACE::operator^;
                   using VMA_HPP_NAMESPACE::operator~;
-                  using VMA_HPP_NAMESPACE::to_string;
                   using VMA_HPP_NAMESPACE::functionsFromDispatcher;
+                  {{{using VMA_HPP_NAMESPACE::${toString};}}}
                 }
 
                 """, Stream.concat(Stream.concat(enums.stream(), structs.stream()), handles.stream()
@@ -943,7 +943,7 @@ public class Generate {
 
                 #ifndef VULKAN_HPP_NO_TO_STRING
                 export namespace VMA_HPP_NAMESPACE {
-                  {{{using VMA_HPP_NAMESPACE::${toString};}}}
+                  using VMA_HPP_NAMESPACE::to_string;
                 }
                 #endif
 

--- a/src/vk_mem_alloc.cppm
+++ b/src/vk_mem_alloc.cppm
@@ -17,7 +17,6 @@ export namespace VMA_HPP_NAMESPACE {
   using VMA_HPP_NAMESPACE::operator&;
   using VMA_HPP_NAMESPACE::operator^;
   using VMA_HPP_NAMESPACE::operator~;
-  using VMA_HPP_NAMESPACE::to_string;
   using VMA_HPP_NAMESPACE::functionsFromDispatcher;
   using VMA_HPP_NAMESPACE::AllocatorCreateFlagBits;
   using VMA_HPP_NAMESPACE::AllocatorCreateFlags;
@@ -75,6 +74,12 @@ export namespace VMA_HPP_NAMESPACE {
   using VMA_HPP_NAMESPACE::UniqueVirtualBlock;
   using VMA_HPP_NAMESPACE::createAllocatorUnique;
   using VMA_HPP_NAMESPACE::createVirtualBlockUnique;
+}
+#endif
+
+#ifndef VULKAN_HPP_NO_TO_STRING
+export namespace VMA_HPP_NAMESPACE {
+  using VMA_HPP_NAMESPACE::to_string;
 }
 #endif
 


### PR DESCRIPTION
When using `Vulkan-Hpp` with `VULKAN_HPP_NO_TO_STRING`, the C++20 module breaks due to being unable to find the `to_string` symbol. I therefore just hid it behind an `#ifndef`.