### PR TITLE
Hide msvc warning suppression pragma behind gate

### DIFF
--- a/VmaHppGenerator.cpp
+++ b/VmaHppGenerator.cpp
@@ -1975,7 +1975,9 @@ void generateHandles(const Source& source, Symbols& symbols) {
     #endif
 
     #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    #pragma warning(disable : 4834) // MSVC thinks we are discarding chained return values, like foo(), detail::wrap<...>(...)
+    #if defined( _MSC_VER )
+    #  pragma warning(disable : 4834) // MSVC thinks we are discarding chained return values, like foo(), detail::wrap<...>(...)
+    #endif
     namespace VMA_HPP_NAMESPACE {
       namespace VMA_HPP_RAII_NAMESPACE {
         namespace detail {

--- a/include/vk_mem_alloc_raii.hpp
+++ b/include/vk_mem_alloc_raii.hpp
@@ -8,7 +8,9 @@
 #endif
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-#pragma warning(disable : 4834) // MSVC thinks we are discarding chained return values, like foo(), detail::wrap<...>(...)
+#if defined( _MSC_VER )
+#  pragma warning(disable : 4834) // MSVC thinks we are discarding chained return values, like foo(), detail::wrap<...>(...)
+#endif
 namespace VMA_HPP_NAMESPACE {
   namespace VMA_HPP_RAII_NAMESPACE {
     namespace detail {


### PR DESCRIPTION
Non-MSVC compilers will complain otherwise; as an example from Clang 21:
```bash
In file included from include/vk_mem_alloc.cppm:6:
include/vk_mem_alloc_raii.hpp:11:9: warning: unknown pragma ignored [-Wunknown-pragmas]
   11 | #pragma warning(disable : 4834) // MSVC thinks we are discarding chained return values, like foo(), detail::wrap<...>(...)
      |         ^
```

This pragma is now hidden behind `#if defined( _MSC_VER )`, similar to how Vulkan-Hpp does it.